### PR TITLE
Wire Streamlit non-compliance priors into batch sim

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -385,7 +385,7 @@ def run_batch(runs: int = 5000, seed: int = 26, scenario: str = "Head-on",
         mode, sense_cat_exec, cat_delay_exec, cat_accel_exec, cat_vs_exec, cat_cap_exec = apply_non_compliance_to_cat(
             rng, sense_ca, base_delay_s=cat_delay_eff, base_accel_g=cat_accel_eff,
             vs_fpm=CAT_INIT_VS_FPM, cap_fpm=CAT_CAP_INIT_FPM,
-            p_opp=0.010, p_taonly=0.003, p_weak=0.300, jitter=True
+            p_opp=p_opp, p_taonly=p_ta, p_weak=p_weak, jitter=jitter_priors
         )
 
         # PL delay distribution


### PR DESCRIPTION
## Summary
- propagate the Streamlit non-compliance slider values through `run_batch` into `apply_non_compliance_to_cat`

## Testing
- python - <<'PY'
import calculator

def summarize(p_opp, p_ta, p_weak):
    df = calculator.run_batch(runs=200, seed=42, p_opp=p_opp, p_ta=p_ta, p_weak=p_weak, jitter_priors=False)
    return df['eventtype'].value_counts(normalize=True)

for label, params in {
    'baseline': (0.01, 0.003, 0.3),
    'high_opp': (0.5, 0.003, 0.3),
    'high_ta': (0.01, 0.5, 0.3),
    'high_weak': (0.01, 0.003, 0.8),
}.items():
    print(label)
    print(summarize(*params))
    print('-'*20)
PY

------
https://chatgpt.com/codex/tasks/task_e_68debc5ab0f48324b818459e6dc6542e