### PR TITLE
Stabilize PL timing and custom t_go sampling

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -16,6 +16,7 @@ Implements the requested amendments on top of your functioning codebase:
 from __future__ import annotations
 
 import io
+from typing import Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -29,6 +30,7 @@ from simulation import (
     CAT_CAP_STRENGTH_FPM,
     CAT_INIT_VS_FPM,
     CAT_STRENGTH_FPM,
+    PL_DELAY_MEAN_S,
     PL_ACCEL_G,
     PL_IAS_KT,
     PL_VS_CAP_FPM,
@@ -36,6 +38,7 @@ from simulation import (
     ias_to_tas,
     integrate_altitude_from_vs,
     run_batch,
+    sanitize_tgo_bounds,
     time_to_go_from_geometry,
     vs_time_series,
 )
@@ -45,6 +48,30 @@ ALIM_CHOICES = [
     ("FL100–FL200 (400 ft)", 400.0),
     ("FL200–FL420 (600 ft)", 600.0),
 ]
+
+APFD_DEFAULT_MODE = "custom"
+APFD_DEFAULT_SHARE = 0.35
+APFD_CUSTOM_SHARE_KEY = "apfd_custom_share"
+APFD_OPTION_KEY = "apfd_option"
+APFD_PRESET_MAP = {
+    "Mixed global traffic (10%)": ("mixed", 0.10),
+    "Airbus-centric (30%)": ("airbus", 0.30),
+}
+
+
+def sanitize_apfd_config(option: str, share_value: Optional[float]) -> Tuple[str, float]:
+    """Return a valid AP/FD mode string and share bounded to [0, 1]."""
+
+    if option in APFD_PRESET_MAP:
+        return APFD_PRESET_MAP[option]
+
+    # Default to the custom selection when the option is unrecognised.
+    try:
+        share = float(share_value if share_value is not None else APFD_DEFAULT_SHARE)
+    except (TypeError, ValueError):
+        share = APFD_DEFAULT_SHARE
+    share = float(np.clip(share, 0.0, 1.0))
+    return APFD_DEFAULT_MODE, share
 
 # ------------------------------- Streamlit UI -------------------------------
 
@@ -97,8 +124,13 @@ with st.sidebar:
                 step=0.5,
                 help="Minimum and maximum t_go bounds used when sampling encounters. The implied mean is clamped to 24–26 s."
             )
+            tgo_window = sanitize_tgo_bounds(tgo_minmax[0], tgo_minmax[1])
+            st.caption(
+                "When enabled the single-run demo and batch sampler use the selected t_go window instead of the range inputs."
+            )
         else:
             tgo_minmax = (None, None)
+            tgo_window = None
         if scenario == "Custom":
             hdg1_min = st.number_input("PL heading min (deg)", value=0.0, step=5.0,
                                        help="Minimum heading for the protected aircraft when sampling custom runs.")
@@ -128,6 +160,9 @@ with st.sidebar:
             value=True,
             help="Randomly perturb the prior probabilities each batch to reflect modelling uncertainty."
         )
+        if APFD_CUSTOM_SHARE_KEY not in st.session_state:
+            st.session_state[APFD_CUSTOM_SHARE_KEY] = APFD_DEFAULT_SHARE
+
         apfd_option = st.selectbox(
             "AP/FD configuration",
             [
@@ -135,26 +170,31 @@ with st.sidebar:
                 "Mixed global traffic (10%)",
                 "Airbus-centric (30%)",
             ],
+            key=APFD_OPTION_KEY,
             help="Choose how autopilot/flight-director usage is represented in the Monte Carlo runs."
         )
+
+        apfd_raw_share = st.session_state.get(APFD_CUSTOM_SHARE_KEY, APFD_DEFAULT_SHARE)
+
         if apfd_option == "Custom share":
-            apfd_mode = "custom"
-            apfd_share = st.slider(
+            apfd_raw_share = st.slider(
                 "AP/FD share",
                 0.0,
                 1.0,
-                0.35,
-                0.05,
+                value=float(apfd_raw_share),
+                step=0.05,
+                key=APFD_CUSTOM_SHARE_KEY,
                 help="Share of crews flying via AP/FD, which lowers delay and slightly boosts acceleration."
             )
-        elif apfd_option.startswith("Mixed"):
-            apfd_mode = "mixed"
-            apfd_share = 0.10
-            st.caption("Mixed global traffic fixes AP/FD usage at 10% with deterministic CAT kinematics for that share.")
-        else:
-            apfd_mode = "airbus"
-            apfd_share = 0.30
-            st.caption("Airbus-centric traffic fixes AP/FD usage at 30% with deterministic CAT kinematics for that share.")
+        elif apfd_option in APFD_PRESET_MAP:
+            preset_mode, _ = APFD_PRESET_MAP[apfd_option]
+            if preset_mode == "mixed":
+                st.caption("Mixed global traffic fixes AP/FD usage at 10% with deterministic CAT kinematics for that share.")
+            elif preset_mode == "airbus":
+                st.caption("Airbus-centric traffic fixes AP/FD usage at 30% with deterministic CAT kinematics for that share.")
+
+        apfd_mode, apfd_share = sanitize_apfd_config(apfd_option, apfd_raw_share)
+        apfd_share_sanitized = float(apfd_share)
         st.markdown("**Non-compliance priors** (updated baseline)")
         p_opp = st.number_input(
             "P(opposite-sense)",
@@ -226,7 +266,12 @@ with tabs[0]:
         cat_tas = ias_to_tas(float(cat_ias_user), single_alt_ft)
         closure_kt = pl_tas + cat_tas
 
-        t_cpa = time_to_go_from_geometry(float(initial_range_nm), closure_kt)
+        initial_range_effective = float(initial_range_nm)
+        if use_custom_tgo and tgo_window is not None and closure_kt > 1e-6:
+            t_cpa = float(np.clip(tgo_window[2], tgo_window[0], tgo_window[1]))
+            initial_range_effective = (closure_kt * t_cpa) / 3600.0
+        else:
+            t_cpa = time_to_go_from_geometry(initial_range_effective, closure_kt)
 
         if t_cpa is None:
             st.warning("Closure rate is zero or negative; CPA cannot be determined.")
@@ -239,7 +284,7 @@ with tabs[0]:
             else:
                 sense_cat = 0
 
-            times, vs_pl = vs_time_series(t_cpa, float(dt), 0.9, PL_ACCEL_G, PL_VS_FPM,
+            times, vs_pl = vs_time_series(t_cpa, float(dt), PL_DELAY_MEAN_S, PL_ACCEL_G, PL_VS_FPM,
                                           sense=sense_pl, cap_fpm=PL_VS_CAP_FPM, vs0_fpm=0.0)
 
             if sense_cat == 0 or cat_vs_user <= 1e-6:
@@ -267,7 +312,7 @@ with tabs[0]:
 
             st.markdown(
                 f"**Scenario**: Head-on at FL{SINGLE_FL}, PL IAS {PL_IAS_KT:.0f} kt (TAS {pl_tas:.1f} kt), "
-                f"CAT IAS {cat_ias_user:.0f} kt (TAS {cat_tas:.1f} kt)."
+                f"CAT IAS {cat_ias_user:.0f} kt (TAS {cat_tas:.1f} kt), initial range {initial_range_effective:.2f} NM."
             )
 
             c_metric1, c_metric2, c_metric3, c_metric4 = st.columns(4)
@@ -300,7 +345,7 @@ with tabs[1]:
             r0_min_nm=float(r0_min), r0_max_nm=float(r0_max),
             aggressiveness=float(aggressiveness),
             p_opp=float(p_opp), p_ta=float(p_ta), p_weak=float(p_weak),
-            jitter_priors=bool(jitter), apfd_share=float(apfd_share),
+            jitter_priors=bool(jitter), apfd_share=apfd_share_sanitized,
             use_delay_mixture=True,
             dt=0.1,
             hdg1_min=float(hdg1_min), hdg1_max=float(hdg1_max),
@@ -321,7 +366,10 @@ with tabs[1]:
         report_alim_outside = st.checkbox(
             "Report ALIM @ CPA outside ±1 s window",
             value=False,
-            help="When enabled the displayed ALIM@CPA metric ignores breaches occurring within ±1 s of CPA."
+            help=(
+                "When enabled the CPA metric uses the minimum separation within ±1 s of CPA; a companion metric highlights"
+                " breaches that only occur outside that window."
+            ),
         )
         total_runs = len(df)
         safe_total = max(total_runs, 1)
@@ -330,22 +378,28 @@ with tabs[1]:
         p_str = (df['eventtype'] == "STRENGTHEN").sum() / safe_total
         p_none = (df['eventtype'] == "NONE").sum() / safe_total
         p_alim_any = (df['margin_min_ft'] < 0.0).sum() / safe_total
-        p_alim_cpa = df['alim_breach_cpa'].sum() / safe_total
-        p_alim_margin = df['alim_breach_margin'].sum() / safe_total
+        sep_reference = df['sep_cpa_ft']
+        alim_cpa_series = df['alim_breach_cpa']
+        if report_alim_outside:
+            sep_reference = df.get('sep_window_min_ft', sep_reference)
+            alim_cpa_series = df.get('alim_breach_cpa_window', df['alim_breach_margin'])
+        p_alim_cpa = alim_cpa_series.sum() / safe_total
+        p_alim_window = df['alim_breach_margin'].sum() / safe_total
         p_alim_outside = df['alim_breach_outside'].sum() / safe_total
         c1.metric("P(Reversal)", f"{100 * p_rev:,.2f}%")
         c2.metric("P(Strengthen)", f"{100 * p_str:,.2f}%")
         c3.metric("P(None)", f"{100 * p_none:,.2f}%")
         c4.metric("P(ALIM Any)", f"{100 * p_alim_any:,.2f}%")
         if report_alim_outside:
-            c5.metric("P(ALIM @ CPA outside ±1 s)", f"{100 * p_alim_outside:,.2f}%")
+            c5.metric("P(ALIM @ CPA (±1 s window))", f"{100 * p_alim_cpa:,.2f}%")
+            c6.metric("P(ALIM outside ±1 s)", f"{100 * p_alim_outside:,.2f}%")
         else:
             c5.metric("P(ALIM @ CPA)", f"{100 * p_alim_cpa:,.2f}%")
-        c6.metric("P(ALIM within ±1 s)", f"{100 * p_alim_margin:,.2f}%")
-        st.caption("Percentages describe RA outcomes alongside ALIM breaches at CPA, within ±1 s, and anywhere in the run.")
-        near_25 = (df['sep_cpa_ft'] - df['ALIM_ft']).abs() <= 25.0
-        near_50 = (df['sep_cpa_ft'] - df['ALIM_ft']).abs() <= 50.0
-        near_100 = (df['sep_cpa_ft'] - df['ALIM_ft']).abs() <= 100.0
+            c6.metric("P(ALIM within ±1 s)", f"{100 * p_alim_window:,.2f}%")
+        st.caption("Percentages describe RA outcomes alongside ALIM breaches at CPA, respecting the selected ±1 s window option, and anywhere in the run.")
+        near_25 = (sep_reference - df['ALIM_ft']).abs() <= 25.0
+        near_50 = (sep_reference - df['ALIM_ft']).abs() <= 50.0
+        near_100 = (sep_reference - df['ALIM_ft']).abs() <= 100.0
         near_25_rate = near_25.sum() / safe_total
         near_50_rate = near_50.sum() / safe_total
         near_100_rate = near_100.sum() / safe_total
@@ -418,7 +472,7 @@ with tabs[1]:
             "Left: outcome mix across the batch. Right: how initial vertical separation trends with reversal/strengthen events."
         )
 
-        margin = df['sep_cpa_ft'] - df['ALIM_ft']
+        margin = sep_reference - df['ALIM_ft']
         breach_mask = margin < 0.0
         fig2, ax2 = plt.subplots(figsize=(8, 5))
 
@@ -443,7 +497,7 @@ with tabs[1]:
                 edgecolors='#000000',
                 s=60,
                 linewidths=0.8,
-                label='ALIM breach @ CPA',
+                label='ALIM breach (selected CPA metric)',
             )
 
         ax2.axhline(0.0, color='k', linestyle='--', linewidth=1, alpha=0.7)

--- a/simulation.py
+++ b/simulation.py
@@ -21,8 +21,8 @@ FT_PER_M = 3.28084
 MS_PER_FPM = 0.00508      # 1 fpm = 0.00508 m/s
 
 # PL (performance-limited) parameters
-PL_DELAY_MEAN_S = 2.2    # adjust if you require 0.9 s globally
-PL_DELAY_SD_S   = 0.4
+PL_DELAY_MEAN_S = 0.9
+PL_DELAY_SD_S   = 0.0
 PL_ACCEL_G      = 0.10
 PL_VS_FPM       = 500.0
 PL_VS_CAP_FPM   = 500.0
@@ -40,6 +40,22 @@ TGO_MAX_S = 35.0
 
 # ALIM margin for classification conservatism (ft)
 ALIM_MARGIN_FT = 100.0
+
+
+def sanitize_tgo_bounds(
+    tgo_min_s: Optional[float], tgo_max_s: Optional[float]
+) -> Tuple[float, float, float, float]:
+    """Return (lo, hi, mode, spread) for custom t_go windows."""
+
+    lo_raw = TGO_MIN_S if tgo_min_s is None else float(tgo_min_s)
+    hi_raw = TGO_MAX_S if tgo_max_s is None else float(tgo_max_s)
+    lo = float(np.clip(lo_raw, TGO_MIN_S, TGO_MAX_S))
+    hi = float(np.clip(hi_raw, TGO_MIN_S, TGO_MAX_S))
+    if hi <= lo + 1e-3:
+        hi = min(TGO_MAX_S, lo + 1.0)
+    mode = float(0.5 * (lo + hi))
+    spread = max(hi - lo, 0.5)
+    return lo, hi, mode, spread
 
 # ------------------------ Utility functions ------------------------
 
@@ -426,7 +442,7 @@ def apply_second_phase(
     pl_accel_g: float = PL_ACCEL_G,
     pl_cap: float = PL_VS_CAP_FPM,
     cat_delay: float = 1.0,
-    cat_accel_g: float = 0.20,
+    cat_accel_g: float = 0.35,
     cat_vs_strength: float = CAT_STRENGTH_FPM,
     cat_cap: float = CAT_CAP_STRENGTH_FPM,
     decision_latency_s: float = 1.0,
@@ -560,6 +576,11 @@ def run_batch(
         apfd_mode_key = "custom"
         apfd_share_effective = float(np.clip(apfd_share, 0.0, 1.0))
 
+    if use_custom_tgo:
+        lo_user, hi_user, mode_user, _ = sanitize_tgo_bounds(tgo_min_s, tgo_max_s)
+    else:
+        lo_user = hi_user = mode_user = None
+
     for k in range(int(runs)):
         FL_PL, FL_CAT, h0 = sample_altitudes_and_h0(rng)
         cat_above = (FL_CAT > FL_PL) if (FL_CAT != FL_PL) else (rng.uniform() < 0.5)
@@ -574,34 +595,41 @@ def run_batch(
             h2 = float(rng.uniform(hdg2_min, hdg2_max))
         else:
             h1, h2 = sample_headings(rng, scenario, 0.0, 360.0, rel_min, rel_max)
-        r0 = float(rng.uniform(min(r0_min_nm, r0_max_nm), max(r0_min_nm, r0_max_nm)))
         vcl = relative_closure_kt(PL_TAS, h1, CAT_TAS, h2)
-        tgo_geom = time_to_go_from_geometry(r0, vcl)
-
-        if use_custom_tgo:
-            lo_user = float(np.clip(tgo_min_s if tgo_min_s is not None else TGO_MIN_S, TGO_MIN_S, TGO_MAX_S))
-            hi_user = float(np.clip(tgo_max_s if tgo_max_s is not None else TGO_MAX_S, TGO_MIN_S, TGO_MAX_S))
-            if hi_user <= lo_user + 1e-3:
-                hi_user = min(TGO_MAX_S, lo_user + 1.0)
-            mu = float(np.clip(0.5 * (lo_user + hi_user), 24.0, 26.0))
-            sd = max((hi_user - lo_user) / 6.0, 0.5)
-            lo = lo_user
-            hi = hi_user
+        if use_custom_tgo and vcl > 1e-6:
+            lo = float(lo_user)
+            hi = float(hi_user)
+            mode = float(mode_user)
+            tgo = float(rng.triangular(lo, mode, hi))
+            r0 = (vcl * tgo) / 3600.0
         else:
-            if scenario == "Head-on":
-                mu, sd = 25.0, 5.0
-            elif scenario == "Crossing":
-                mu, sd = 22.0, 6.0
+            r0 = float(rng.uniform(min(r0_min_nm, r0_max_nm), max(r0_min_nm, r0_max_nm)))
+            tgo_geom = time_to_go_from_geometry(r0, vcl)
+            if use_custom_tgo:
+                lo = float(lo_user)
+                hi = float(hi_user)
+                mode = float(mode_user)
             else:
-                mu, sd = 30.0, 8.0
-            lo = TGO_MIN_S
-            hi = TGO_MAX_S
-        geom_limit = tgo_geom if tgo_geom is not None else TGO_MAX_S
-        hi = min(hi, geom_limit)
-        hi = float(np.clip(hi, lo + 0.5, TGO_MAX_S))
-        if hi <= lo + 1e-3:
-            hi = min(TGO_MAX_S, lo + 1.0)
-        tgo = float(np.clip(rng.normal(mu, sd), lo, hi))
+                lo = TGO_MIN_S
+                hi = TGO_MAX_S
+                if scenario == "Head-on":
+                    mu, sd = 25.0, 5.0
+                elif scenario == "Crossing":
+                    mu, sd = 22.0, 6.0
+                else:
+                    mu, sd = 30.0, 8.0
+            if tgo_geom is not None:
+                hi = min(hi, tgo_geom)
+            hi = float(np.clip(hi, lo + 0.5, TGO_MAX_S))
+            if hi <= lo + 1e-3:
+                hi = min(TGO_MAX_S, lo + 1.0)
+            if use_custom_tgo:
+                tgo = float(rng.triangular(lo, mode, hi))
+            else:
+                tgo = float(np.clip(rng.normal(mu, sd), lo, hi))
+            if use_custom_tgo and vcl <= 1e-6:
+                # Degenerate geometry; retain user-specified range settings.
+                r0 = float(rng.uniform(min(r0_min_nm, r0_max_nm), max(r0_min_nm, r0_max_nm)))
 
         leveloff_context = aggressiveness <= 1e-6
         vz0_pl = sample_initial_vs_with_aggressiveness(rng, aggressiveness, leveloff_context)
@@ -686,7 +714,7 @@ def run_batch(
                     jitter=jitter_priors,
                 )
 
-        pl_delay = max(0.0, rng.normal(PL_DELAY_MEAN_S, PL_DELAY_SD_S))
+        pl_delay = PL_DELAY_MEAN_S
 
         times, vs_pl = vs_time_series(
             tgo,
@@ -744,7 +772,7 @@ def run_batch(
                 pl_accel_g=PL_ACCEL_G,
                 pl_cap=PL_VS_CAP_FPM,
                 cat_delay=1.0,
-                cat_accel_g=0.20,
+                cat_accel_g=0.35,
                 cat_vs_strength=CAT_STRENGTH_FPM,
                 cat_cap=CAT_CAP_STRENGTH_FPM,
                 decision_latency_s=float(np.clip(rng.normal(1.0, 0.2), 0.6, 1.4)),
@@ -760,13 +788,15 @@ def run_batch(
         sep_trace = np.abs(z_ca - z_pl)
         miss_cpa_ft = float(abs(z_ca[-1] - z_pl[-1]))
         margin_trace = sep_trace - alim_ft
-        window_mask = times >= (times[-1] - 1.0)
+        cpa_time = float(times[-1])
+        window_mask = np.abs(times - cpa_time) <= 1.0
         if not np.any(window_mask):
             window_mask[-1] = True
         outside_mask = ~window_mask
         sep_window_min_ft = float(np.min(sep_trace[window_mask]))
         alim_breach_cpa = bool(sep_trace[-1] < alim_ft)
-        alim_breach_margin = bool(np.any(sep_trace[window_mask] < alim_ft))
+        alim_breach_cpa_window = bool(np.any(sep_trace[window_mask] < alim_ft))
+        alim_breach_margin = alim_breach_cpa_window
         alim_breach_outside = bool(np.any(sep_trace[outside_mask] < alim_ft)) if np.any(outside_mask) else False
         margin_min_ft = float(np.min(margin_trace))
 
@@ -814,6 +844,7 @@ def run_batch(
                 sep_window_min_ft=sep_window_min_ft,
                 margin_min_ft=margin_min_ft,
                 alim_breach_cpa=alim_breach_cpa,
+                alim_breach_cpa_window=alim_breach_cpa_window,
                 alim_breach_margin=alim_breach_margin,
                 alim_breach_outside=alim_breach_outside,
                 eventtype=eventtype,
@@ -859,6 +890,7 @@ __all__ = [
     "alim_ft_from_alt",
     "first_move_time",
     "compliance_score_method_b_like",
+    "sanitize_tgo_bounds",
     "sample_initial_vs_with_aggressiveness",
     "simulate_miss_for_senses",
     "choose_optimal_sense",

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -8,7 +8,9 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from simulation import (
     CAT_CAP_INIT_FPM,
+    CAT_CAP_STRENGTH_FPM,
     CAT_INIT_VS_FPM,
+    CAT_STRENGTH_FPM,
     PL_ACCEL_G,
     PL_VS_CAP_FPM,
     PL_VS_FPM,
@@ -52,9 +54,9 @@ def test_apply_second_phase_reverse_changes_sense():
         pl_accel_g=PL_ACCEL_G,
         pl_cap=PL_VS_CAP_FPM,
         cat_delay=1.0,
-        cat_accel_g=0.20,
-        cat_vs_strength=CAT_INIT_VS_FPM,
-        cat_cap=CAT_CAP_INIT_FPM,
+        cat_accel_g=0.35,
+        cat_vs_strength=CAT_STRENGTH_FPM,
+        cat_cap=CAT_CAP_STRENGTH_FPM,
         decision_latency_s=1.0,
     )
 


### PR DESCRIPTION
## Summary
- keep the single-run demo and Monte Carlo batches using the sanitized custom t_go window while sampling with a triangular spread between the user limits to preserve CPA geometry
- fix PL kinematics at the required 0.9 s delay with 0.1 g toward ±500 fpm across sense selection and batch runs, and drive second-phase RAs with 0.35 g toward 2500 fpm
- refresh unit coverage for the revised second-phase parameters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa5bfd7d483248fc60a9b03850330