### PR TITLE
Align kinematics with updated RA requirements

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -31,6 +31,7 @@ from simulation import (
     CAT_INIT_VS_FPM,
     CAT_STRENGTH_FPM,
     PL_ACCEL_G,
+    PL_DELAY_MEAN_S,
     PL_IAS_KT,
     PL_VS_CAP_FPM,
     PL_VS_FPM,
@@ -283,7 +284,7 @@ with tabs[0]:
             else:
                 sense_cat = 0
 
-            times, vs_pl = vs_time_series(t_cpa, float(dt), 0.9, PL_ACCEL_G, PL_VS_FPM,
+            times, vs_pl = vs_time_series(t_cpa, float(dt), PL_DELAY_MEAN_S, PL_ACCEL_G, PL_VS_FPM,
                                           sense=sense_pl, cap_fpm=PL_VS_CAP_FPM, vs0_fpm=0.0)
 
             if sense_cat == 0 or cat_vs_user <= 1e-6:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -8,8 +8,11 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from simulation import (
     CAT_CAP_INIT_FPM,
+    CAT_CAP_STRENGTH_FPM,
     CAT_INIT_VS_FPM,
+    CAT_STRENGTH_FPM,
     PL_ACCEL_G,
+    PL_DELAY_MEAN_S,
     PL_VS_CAP_FPM,
     PL_VS_FPM,
     apply_second_phase,
@@ -33,7 +36,15 @@ def test_apply_second_phase_reverse_changes_sense():
     sense_pl = +1
     sense_cat = -1
 
-    times, vs_pl = vs_time_series(tgo, dt, 1.0, PL_ACCEL_G, PL_VS_FPM, sense=sense_pl, cap_fpm=PL_VS_CAP_FPM)
+    times, vs_pl = vs_time_series(
+        tgo,
+        dt,
+        PL_DELAY_MEAN_S,
+        PL_ACCEL_G,
+        PL_VS_FPM,
+        sense=sense_pl,
+        cap_fpm=PL_VS_CAP_FPM,
+    )
     _, vs_ca = vs_time_series(tgo, dt, 4.0, 0.20, CAT_INIT_VS_FPM, sense=sense_cat, cap_fpm=CAT_CAP_INIT_FPM)
 
     times2, vs_pl2, vs_ca2, t_issue = apply_second_phase(
@@ -48,13 +59,13 @@ def test_apply_second_phase_reverse_changes_sense():
         pl_vs0=0.0,
         cat_vs0=0.0,
         t_classify=8.0,
-        pl_delay=1.0,
+        pl_delay=PL_DELAY_MEAN_S,
         pl_accel_g=PL_ACCEL_G,
         pl_cap=PL_VS_CAP_FPM,
-        cat_delay=1.0,
-        cat_accel_g=0.20,
-        cat_vs_strength=CAT_INIT_VS_FPM,
-        cat_cap=CAT_CAP_INIT_FPM,
+        cat_delay=0.9,
+        cat_accel_g=0.35,
+        cat_vs_strength=CAT_STRENGTH_FPM,
+        cat_cap=CAT_CAP_STRENGTH_FPM,
         decision_latency_s=1.0,
     )
 


### PR DESCRIPTION
## Summary
- lock PL manoeuvre parameters to the prescribed 0.9 s, 0.1 g, ±500 fpm profile and apply compliant CAT accelerations of 0.25 g / 1500 fpm
- switch custom t_go handling to a midpoint-based triangular sampler and propagate the change through the Streamlit UI and batch runner
- strengthen second-phase CAT parameters to 0.35 g / 2500 fpm and update the unit tests accordingly while tying AP/FD runs to a deterministic 0.9 s delay

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfb20431c08324a0ac67987aeba02c