### PR TITLE
Rework RA escalation logic and align weak strengthen profiles

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -31,6 +31,7 @@ from simulation import (
     CAT_INIT_VS_FPM,
     CAT_STRENGTH_FPM,
     PL_ACCEL_G,
+    PL_DELAY_MEAN_S,
     PL_IAS_KT,
     PL_VS_CAP_FPM,
     PL_VS_FPM,
@@ -283,7 +284,7 @@ with tabs[0]:
             else:
                 sense_cat = 0
 
-            times, vs_pl = vs_time_series(t_cpa, float(dt), 0.9, PL_ACCEL_G, PL_VS_FPM,
+            times, vs_pl = vs_time_series(t_cpa, float(dt), PL_DELAY_MEAN_S, PL_ACCEL_G, PL_VS_FPM,
                                           sense=sense_pl, cap_fpm=PL_VS_CAP_FPM, vs0_fpm=0.0)
 
             if sense_cat == 0 or cat_vs_user <= 1e-6:
@@ -362,12 +363,12 @@ with tabs[1]:
         df = st.session_state['df']
         st.success(f"Completed {len(df)} runs.")
         st.caption(f"ALIM applied: {alim_selection_label} (±{selected_alim_ft:.0f} ft).")
-        report_alim_outside = st.checkbox(
-            "Report ALIM @ CPA outside ±1 s window",
-            value=False,
+        exclude_flex = st.checkbox(
+            "Exclude ALIM−25 ft from breaches",
+            value=True,
             help=(
-                "When enabled the CPA metric uses the minimum separation within ±1 s of CPA; a companion metric highlights"
-                " breaches that only occur outside that window."
+                "When enabled, CPA breaches that remain within 25 ft of ALIM are not counted."
+                " Disable to view the strict ALIM @ CPA rate."
             ),
         )
         total_runs = len(df)
@@ -378,24 +379,22 @@ with tabs[1]:
         p_none = (df['eventtype'] == "NONE").sum() / safe_total
         p_alim_any = (df['margin_min_ft'] < 0.0).sum() / safe_total
         sep_reference = df['sep_cpa_ft']
-        alim_cpa_series = df['alim_breach_cpa']
-        if report_alim_outside:
-            sep_reference = df.get('sep_window_min_ft', sep_reference)
-            alim_cpa_series = df.get('alim_breach_cpa_window', df['alim_breach_margin'])
-        p_alim_cpa = alim_cpa_series.sum() / safe_total
-        p_alim_window = df['alim_breach_margin'].sum() / safe_total
-        p_alim_outside = df['alim_breach_outside'].sum() / safe_total
+        p_alim_cpa_strict = df['alim_breach_cpa'].sum() / safe_total
+        p_alim_cpa_flex = df['alim_breach_cpa_excl25'].sum() / safe_total
         c1.metric("P(Reversal)", f"{100 * p_rev:,.2f}%")
         c2.metric("P(Strengthen)", f"{100 * p_str:,.2f}%")
         c3.metric("P(None)", f"{100 * p_none:,.2f}%")
         c4.metric("P(ALIM Any)", f"{100 * p_alim_any:,.2f}%")
-        if report_alim_outside:
-            c5.metric("P(ALIM @ CPA (±1 s window))", f"{100 * p_alim_cpa:,.2f}%")
-            c6.metric("P(ALIM outside ±1 s)", f"{100 * p_alim_outside:,.2f}%")
+        if exclude_flex:
+            c5.metric("P(ALIM @ CPA excl. 25 ft)", f"{100 * p_alim_cpa_flex:,.2f}%")
+            c6.metric("P(ALIM @ CPA strict)", f"{100 * p_alim_cpa_strict:,.2f}%")
         else:
-            c5.metric("P(ALIM @ CPA)", f"{100 * p_alim_cpa:,.2f}%")
-            c6.metric("P(ALIM within ±1 s)", f"{100 * p_alim_window:,.2f}%")
-        st.caption("Percentages describe RA outcomes alongside ALIM breaches at CPA, respecting the selected ±1 s window option, and anywhere in the run.")
+            c5.metric("P(ALIM @ CPA strict)", f"{100 * p_alim_cpa_strict:,.2f}%")
+            c6.metric("P(ALIM @ CPA excl. 25 ft)", f"{100 * p_alim_cpa_flex:,.2f}%")
+        st.caption(
+            "Percentages describe RA outcomes alongside CPA ALIM breaches with the selected exclusion option"
+            " and the complementary strict rate for comparison."
+        )
         near_25 = (sep_reference - df['ALIM_ft']).abs() <= 25.0
         near_50 = (sep_reference - df['ALIM_ft']).abs() <= 50.0
         near_100 = (sep_reference - df['ALIM_ft']).abs() <= 100.0
@@ -472,7 +471,7 @@ with tabs[1]:
         )
 
         margin = sep_reference - df['ALIM_ft']
-        breach_mask = margin < 0.0
+        breach_mask = df['alim_breach_cpa_excl25'] if exclude_flex else df['alim_breach_cpa']
         fig2, ax2 = plt.subplots(figsize=(8, 5))
 
         for evt in event_order:
@@ -509,9 +508,10 @@ with tabs[1]:
         st.pyplot(fig2)
 
         breach_rate = 100.0 * breach_mask.mean()
+        metric_label = "excluding ALIM−25 ft" if exclude_flex else "strict"
         st.caption(
             "Points below the dashed line represent CPA separations that fail to clear ALIM. "
-            f"{breach_rate:.2f}% of sampled runs breached ALIM at CPA; highlighted markers show where they occur."
+            f"{breach_rate:.2f}% of sampled runs breached ALIM at CPA ({metric_label}); highlighted markers show where they occur."
         )
 
         with st.expander("Inspect an individual run", expanded=False):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -8,10 +8,15 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from simulation import (
     CAT_CAP_INIT_FPM,
+    CAT_CAP_STRENGTH_FPM,
     CAT_INIT_VS_FPM,
+    CAT_STRENGTH_FPM,
     PL_ACCEL_G,
+    PL_DELAY_MEAN_S,
     PL_VS_CAP_FPM,
     PL_VS_FPM,
+    classify_event,
+    integrate_altitude_from_vs,
     apply_second_phase,
     ias_to_tas,
     run_batch,
@@ -33,7 +38,15 @@ def test_apply_second_phase_reverse_changes_sense():
     sense_pl = +1
     sense_cat = -1
 
-    times, vs_pl = vs_time_series(tgo, dt, 1.0, PL_ACCEL_G, PL_VS_FPM, sense=sense_pl, cap_fpm=PL_VS_CAP_FPM)
+    times, vs_pl = vs_time_series(
+        tgo,
+        dt,
+        PL_DELAY_MEAN_S,
+        PL_ACCEL_G,
+        PL_VS_FPM,
+        sense=sense_pl,
+        cap_fpm=PL_VS_CAP_FPM,
+    )
     _, vs_ca = vs_time_series(tgo, dt, 4.0, 0.20, CAT_INIT_VS_FPM, sense=sense_cat, cap_fpm=CAT_CAP_INIT_FPM)
 
     times2, vs_pl2, vs_ca2, t_issue = apply_second_phase(
@@ -48,19 +61,196 @@ def test_apply_second_phase_reverse_changes_sense():
         pl_vs0=0.0,
         cat_vs0=0.0,
         t_classify=8.0,
-        pl_delay=1.0,
+        pl_delay=PL_DELAY_MEAN_S,
         pl_accel_g=PL_ACCEL_G,
         pl_cap=PL_VS_CAP_FPM,
-        cat_delay=1.0,
-        cat_accel_g=0.20,
-        cat_vs_strength=CAT_INIT_VS_FPM,
-        cat_cap=CAT_CAP_INIT_FPM,
+        cat_delay=0.9,
+        cat_accel_g=0.35,
+        cat_vs_strength=CAT_STRENGTH_FPM,
+        cat_cap=CAT_CAP_STRENGTH_FPM,
         decision_latency_s=1.0,
     )
 
     assert t_issue is not None
     assert vs_pl2[-1] < 0.0  # PL reverses to descend eventually
     assert vs_ca2[-1] > 0.0  # CAT reverses to climb eventually
+
+
+def test_classify_event_no_response_escalates_early():
+    tgo = 30.0
+    dt = 0.5
+    sense_pl = +1
+    sense_cat = +1
+
+    times, vs_pl = vs_time_series(
+        tgo,
+        dt,
+        PL_DELAY_MEAN_S,
+        PL_ACCEL_G,
+        PL_VS_FPM,
+        sense=sense_pl,
+        cap_fpm=PL_VS_CAP_FPM,
+    )
+    _, vs_ca = vs_time_series(
+        tgo,
+        dt,
+        5.0,
+        0.0,
+        0.0,
+        sense=sense_cat,
+        cap_fpm=0.0,
+    )
+
+    z_pl = integrate_altitude_from_vs(times, vs_pl, 0.0)
+    z_ca = integrate_altitude_from_vs(times, vs_ca, 1000.0)
+
+    eventtype, _, _, t_detect, _ = classify_event(
+        times,
+        z_pl,
+        z_ca,
+        vs_pl,
+        vs_ca,
+        tgo,
+        alim_ft=400.0,
+        margin_ft=100.0,
+        sense_chosen_cat=sense_cat,
+        sense_exec_cat=sense_cat,
+        cat_mode="no-response",
+        cat_vs_cmd=CAT_INIT_VS_FPM,
+    )
+
+    assert eventtype == "STRENGTHEN"
+    assert np.isclose(t_detect, 3.0, atol=1e-6)
+
+
+def test_apply_second_phase_strengthen_weak_scales_profile():
+    dt = 0.5
+    sense_pl = +1
+    sense_cat = +1
+
+    # Long time-to-go retains the moderated weak profile.
+    tgo_long = 32.0
+    times_long, vs_pl_long = vs_time_series(
+        tgo_long,
+        dt,
+        PL_DELAY_MEAN_S,
+        PL_ACCEL_G,
+        PL_VS_FPM,
+        sense=sense_pl,
+        cap_fpm=PL_VS_CAP_FPM,
+    )
+    _, vs_ca_long = vs_time_series(
+        tgo_long,
+        dt,
+        5.0,
+        0.18,
+        CAT_INIT_VS_FPM,
+        sense=sense_cat,
+        cap_fpm=CAT_CAP_INIT_FPM,
+    )
+
+    times2_long, _, vs_ca2_long, t_issue_long = apply_second_phase(
+        times_long,
+        vs_pl_long,
+        vs_ca_long,
+        tgo_long,
+        dt,
+        eventtype="STRENGTHEN",
+        sense_pl=sense_pl,
+        sense_cat_exec=sense_cat,
+        pl_vs0=0.0,
+        cat_vs0=0.0,
+        t_classify=6.0,
+        pl_delay=PL_DELAY_MEAN_S,
+        pl_accel_g=PL_ACCEL_G,
+        pl_cap=PL_VS_CAP_FPM,
+        cat_delay=0.9,
+        cat_accel_g=0.35,
+        cat_vs_strength=CAT_STRENGTH_FPM,
+        cat_cap=CAT_CAP_STRENGTH_FPM,
+        decision_latency_s=1.0,
+        cat_mode="weak-compliance",
+    )
+
+    assert t_issue_long is not None
+
+    idx_issue_long = int(np.where(np.isclose(times2_long, t_issue_long))[0][0])
+    suffix_vs_long = vs_ca2_long[idx_issue_long:]
+    rem_long = tgo_long - times2_long[idx_issue_long]
+    _, expected_vs_long = vs_time_series(
+        rem_long,
+        dt,
+        0.9,
+        0.25,
+        2200.0,
+        sense=sense_cat,
+        cap_fpm=2400.0,
+        vs0_fpm=vs_ca2_long[idx_issue_long],
+    )
+
+    assert np.allclose(suffix_vs_long, expected_vs_long)
+
+    # Short time-to-go escalates to the exigent profile.
+    tgo_short = 20.0
+    times_short, vs_pl_short = vs_time_series(
+        tgo_short,
+        dt,
+        PL_DELAY_MEAN_S,
+        PL_ACCEL_G,
+        PL_VS_FPM,
+        sense=sense_pl,
+        cap_fpm=PL_VS_CAP_FPM,
+    )
+    _, vs_ca_short = vs_time_series(
+        tgo_short,
+        dt,
+        5.0,
+        0.18,
+        CAT_INIT_VS_FPM,
+        sense=sense_cat,
+        cap_fpm=CAT_CAP_INIT_FPM,
+    )
+
+    times2_short, _, vs_ca2_short, t_issue_short = apply_second_phase(
+        times_short,
+        vs_pl_short,
+        vs_ca_short,
+        tgo_short,
+        dt,
+        eventtype="STRENGTHEN",
+        sense_pl=sense_pl,
+        sense_cat_exec=sense_cat,
+        pl_vs0=0.0,
+        cat_vs0=0.0,
+        t_classify=10.0,
+        pl_delay=PL_DELAY_MEAN_S,
+        pl_accel_g=PL_ACCEL_G,
+        pl_cap=PL_VS_CAP_FPM,
+        cat_delay=0.9,
+        cat_accel_g=0.35,
+        cat_vs_strength=CAT_STRENGTH_FPM,
+        cat_cap=CAT_CAP_STRENGTH_FPM,
+        decision_latency_s=1.0,
+        cat_mode="weak-compliance",
+    )
+
+    assert t_issue_short is not None
+
+    idx_issue_short = int(np.where(np.isclose(times2_short, t_issue_short))[0][0])
+    suffix_vs_short = vs_ca2_short[idx_issue_short:]
+    rem_short = tgo_short - times2_short[idx_issue_short]
+    _, expected_vs_short = vs_time_series(
+        rem_short,
+        dt,
+        0.9,
+        0.35,
+        CAT_STRENGTH_FPM,
+        sense=sense_cat,
+        cap_fpm=CAT_CAP_STRENGTH_FPM,
+        vs0_fpm=vs_ca2_short[idx_issue_short],
+    )
+
+    assert np.allclose(suffix_vs_short, expected_vs_short)
 
 
 def test_run_batch_deterministic_seed():
@@ -81,3 +271,25 @@ def test_run_batch_deterministic_seed():
 
     assert len(df1) == len(df2) == 20
     pdt.assert_frame_equal(df1.reset_index(drop=True), df2.reset_index(drop=True))
+
+
+def test_run_batch_apfd_custom_matches_preset():
+    df_custom = run_batch(
+        runs=100,
+        seed=777,
+        jitter_priors=False,
+        use_delay_mixture=False,
+        apfd_share=0.30,
+        apfd_mode="custom",
+    )
+
+    df_preset = run_batch(
+        runs=100,
+        seed=777,
+        jitter_priors=False,
+        use_delay_mixture=False,
+        apfd_share=0.30,
+        apfd_mode="airbus",
+    )
+
+    pdt.assert_frame_equal(df_custom.reset_index(drop=True), df_preset.reset_index(drop=True))


### PR DESCRIPTION
## Summary
- drive strengthen and reversal detection from continuous predicted-miss monitoring with time-to-go guards, an early no-response escalation, and a “don’t reverse yet” improvement check
- tune second-phase execution so manual crews honour a 2.5 s delay, weak strengthen commands default to 0.25 g/2200 fpm/2400 fpm, and exigent upgrades reach 0.35 g when time is short
- add regression tests for the manual escalation pathway, weak strengthen profiles, and AP/FD share parity between preset and custom configurations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfb20431c08324a0ac67987aeba02c