### PR TITLE
Keep PL profile fixed during reversal manoeuvres

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -722,7 +722,7 @@ def apply_second_phase(
     vs_pl_now = float(np.interp(t2_issue, times, vs_pl))
     vs_ca_now = float(np.interp(t2_issue, times, vs_ca))
 
-    new_sense_pl = sense_pl if eventtype == "STRENGTHEN" else -sense_pl
+    new_sense_pl = sense_pl
     new_sense_cat = sense_cat_exec if eventtype == "STRENGTHEN" else -sense_cat_exec
 
     mode_key = (cat_mode or "").lower().strip()
@@ -754,16 +754,20 @@ def apply_second_phase(
         cat_vs_eff = cat_vs_strength
         cat_cap_eff = cat_cap
 
-    t2_rel, vs_pl_cont = vs_time_series(
-        t_rem,
-        dt,
-        pl_delay,
-        pl_accel_g,
-        pl_cap,
-        sense=new_sense_pl,
-        cap_fpm=pl_cap,
-        vs0_fpm=vs_pl_now,
-    )
+    if eventtype == "REVERSE":
+        t2_rel = np.arange(0.0, t_rem + 1e-9, dt)
+        vs_pl_cont = np.interp(t2_issue + t2_rel, times, vs_pl)
+    else:
+        t2_rel, vs_pl_cont = vs_time_series(
+            t_rem,
+            dt,
+            pl_delay,
+            pl_accel_g,
+            pl_cap,
+            sense=new_sense_pl,
+            cap_fpm=pl_cap,
+            vs0_fpm=vs_pl_now,
+        )
     _, vs_ca_cont = vs_time_series(
         t_rem,
         dt,
@@ -1165,7 +1169,6 @@ def run_batch(
             )
 
             if eventtype == "REVERSE":
-                current_sense_pl = -current_sense_pl
                 current_sense_cat_exec = -current_sense_cat_exec
                 current_sense_chosen = -current_sense_chosen
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -65,7 +65,7 @@ def test_vs_time_series_post_delay_slope_matches_commanded_accel():
         assert np.allclose(slopes, sense * expected_slope, atol=1e-6)
 
 
-def test_apply_second_phase_reverse_changes_sense():
+def test_apply_second_phase_reverse_keeps_pl_profile():
     tgo = 20.0
     dt = 0.5
     sense_pl = +1
@@ -105,7 +105,15 @@ def test_apply_second_phase_reverse_changes_sense():
     )
 
     assert t_issue is not None
-    assert vs_pl2[-1] < 0.0  # PL reverses to descend eventually
+
+    interpolated_pl = np.interp(times2, times, vs_pl)
+    assert np.allclose(vs_pl2, interpolated_pl)
+
+    z_pl_orig = integrate_altitude_from_vs(times, vs_pl, 0.0)
+    z_pl2 = integrate_altitude_from_vs(times2, vs_pl2, 0.0)
+    interpolated_z = np.interp(times2, times, z_pl_orig)
+    assert np.allclose(z_pl2, interpolated_z)
+    assert vs_pl2[-1] > 0.0  # PL continues original climb sense
     assert vs_ca2[-1] > 0.0  # CAT reverses to climb eventually
 
 


### PR DESCRIPTION
## Summary
- keep the performance-limited profile and sense unchanged during reversal events while recomputing the intruder trajectory
- remove downstream PL sense flipping so separation evaluation works with an unchanged profile
- extend the regression coverage to assert the PL profile and altitude trace remain steady through reversals

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0124c98bc83248770afe284648e4b