### PR TITLE
Require ALIM margin for reversal projection

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -485,6 +485,15 @@ def apply_non_compliance_to_cat(
 # ------------------------- Event classification -------------------------
 
 
+def reversal_candidate_satisfies_alim(
+    cpa_reverse: float, alim_ft: float, margin_ft: float
+) -> bool:
+    """Return True when a reversal projection meets the ALIM + margin gate."""
+
+    reverse_threshold_ft = alim_ft + margin_ft
+    return cpa_reverse >= reverse_threshold_ft
+
+
 def classify_event(
     times: np.ndarray,
     z_pl: np.ndarray,
@@ -754,10 +763,7 @@ def classify_event(
             cpa_continue = float(np.min(sep_continue))
             cpa_reverse = float(np.min(sep_reverse))
 
-            reverse_alim_ok = cpa_reverse >= (alim_ft + margin_ft)
-            reverse_better = cpa_reverse > cpa_continue + 1e-3
-
-            if not (reverse_alim_ok or reverse_better):
+            if not reversal_candidate_satisfies_alim(cpa_reverse, alim_ft, margin_ft):
                 prev_time = float(t_now)
                 continue
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -763,6 +763,13 @@ def test_classify_event_reversal_not_selected_when_cpa_worsens():
         assert event_detail in {None, "EXIGENT_STRENGTHEN"}
 
 
+def test_reversal_candidate_satisfies_alim_gate():
+    from simulation import reversal_candidate_satisfies_alim
+
+    assert not reversal_candidate_satisfies_alim(499.0, 400.0, 100.0)
+    assert reversal_candidate_satisfies_alim(500.0, 400.0, 100.0)
+
+
 def test_classify_event_same_sense_improvement_hold_defers_reversal():
     closure_fps = 20.0
     times = np.array([0.0, 0.4, 0.8, 1.2, 1.6, 2.0, 2.4, 2.8])


### PR DESCRIPTION
## Summary
- require reversal projections to satisfy the ALIM plus margin threshold before allowing a reversal
- add a focused unit test covering the new reversal gate helper

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0d06dbed0832499553d3d9d862d4e