### PR TITLE
Add CPA-focused preview filter and align run inspector

### DIFF
--- a/preview_filters.py
+++ b/preview_filters.py
@@ -1,0 +1,39 @@
+"""Preview filtering utilities for the Monte Carlo Streamlit app."""
+from __future__ import annotations
+
+import pandas as pd
+
+LOWEST_SEPARATION_WINDOW_FT = 300.0
+
+
+def build_preview_dataframe(
+    df: pd.DataFrame,
+    *,
+    reversal_only: bool = False,
+    lowest_separation_only: bool = False,
+    window_ft: float = LOWEST_SEPARATION_WINDOW_FT,
+) -> pd.DataFrame:
+    """Return a filtered preview DataFrame respecting the configured options."""
+
+    if df is None:
+        return pd.DataFrame()
+    if df.empty:
+        return df.iloc[0:0]
+
+    preview_df = df
+    if reversal_only:
+        preview_df = preview_df.loc[preview_df["eventtype"] == "REVERSE"]
+
+    if lowest_separation_only:
+        if "sep_cpa_ft" not in df.columns:
+            preview_df = preview_df.iloc[0:0]
+        else:
+            min_sep = df["sep_cpa_ft"].min()
+            if pd.isna(min_sep):
+                preview_df = preview_df.iloc[0:0]
+            else:
+                threshold = float(min_sep) + float(window_ft)
+                preview_df = preview_df.loc[preview_df["sep_cpa_ft"] <= threshold]
+                preview_df = preview_df.sort_values("sep_cpa_ft", ascending=True)
+
+    return preview_df.copy()

--- a/tests/test_preview_filters.py
+++ b/tests/test_preview_filters.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from preview_filters import LOWEST_SEPARATION_WINDOW_FT, build_preview_dataframe
+
+
+def make_df():
+    return pd.DataFrame(
+        {
+            "run": [1, 2, 3, 4],
+            "eventtype": ["NONE", "REVERSE", "STRENGTHEN", "REVERSE"],
+            "sep_cpa_ft": [800.0, 650.0, 900.0, 620.0],
+        }
+    )
+
+
+def test_reversal_filter_only():
+    df = make_df()
+    result = build_preview_dataframe(df, reversal_only=True)
+    assert list(result["run"]) == [2, 4]
+
+
+def test_lowest_separation_window_filters_and_sorts():
+    df = make_df()
+    result = build_preview_dataframe(df, lowest_separation_only=True)
+    min_sep = df["sep_cpa_ft"].min()
+    threshold = min_sep + LOWEST_SEPARATION_WINDOW_FT
+    assert result["sep_cpa_ft"].max() <= threshold
+    assert list(result["sep_cpa_ft"]) == sorted(result["sep_cpa_ft"])  # ascending order
+
+
+def test_combined_filters_apply_in_sequence():
+    df = make_df()
+    result = build_preview_dataframe(df, reversal_only=True, lowest_separation_only=True)
+    assert list(result["run"]) == [4, 2]  # sorted by separation ascending
+    assert (result["eventtype"] == "REVERSE").all()
+
+
+def test_handles_empty_input():
+    df = pd.DataFrame(columns=["run", "eventtype", "sep_cpa_ft"])
+    result = build_preview_dataframe(df, reversal_only=True, lowest_separation_only=True)
+    assert result.empty


### PR DESCRIPTION
## Summary
- add a CPA-focused preview filter alongside the reversal toggle and clarify the table messaging
- drive the run inspection controls from the filtered preview subset and guard empty states
- factor the preview filtering into a helper module with unit coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e10a4b96608324a6f1df460976c959