### PR TITLE
Align residual risk ratio with signed denominator

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -47,6 +47,7 @@ from simulation import (
     integrate_altitude_from_vs,
     OppositeSenseBand,
     derive_single_run_geometry,
+    compute_residual_risk,
     run_batch,
     sanitize_tgo_bounds,
     decode_time_history,
@@ -408,7 +409,7 @@ with tabs[0]:
             miss_cpa = abs(delta_h_cpa)
             delta_pl = float(z_pl[-1] - z_pl[0])
             delta_cat = float(z_cat[-1] - z_cat[0])
-            residual_risk = abs(delta_cat) / max(abs(delta_pl), 1e-3) * 0.011
+            residual_risk = compute_residual_risk(delta_pl, delta_cat)
 
             st.markdown(
                 f"**Scenario**: Head-on at FL{SINGLE_FL}, PL IAS {PL_IAS_KT:.0f} kt (TAS {pl_tas:.1f} kt), "

--- a/simulation.py
+++ b/simulation.py
@@ -176,6 +176,13 @@ def encode_time_history(
     return json.dumps(payload, separators=(",", ":"))
 
 
+def compute_residual_risk(delta_pl: float, delta_cat: float) -> float:
+    """Return the residual risk ratio using a signed, epsilon-guarded PL delta."""
+
+    guard = delta_pl if abs(delta_pl) >= 1e-3 else math.copysign(1e-3, delta_pl or 1.0)
+    return delta_cat / guard * 0.011
+
+
 def decode_time_history(value: object) -> Optional[Dict[str, np.ndarray]]:
     """Decode trajectory histories stored by :func:`encode_time_history`."""
 
@@ -1839,8 +1846,7 @@ def run_batch(
 
         delta_pl = float(z_pl[-1] - z_pl[0])
         delta_cat = float(z_ca[-1] - z_ca[0])
-        denom = max(abs(delta_pl), 1e-3)
-        residual_risk = abs(delta_cat) / denom * 0.011
+        residual_risk = compute_residual_risk(delta_pl, delta_cat)
 
         comp_label = compliance_score_method_b_like(
             sense_required=sense_cat_exec,
@@ -1947,6 +1953,7 @@ __all__ = [
     "MAX_MANEUVER_PHASES",
     # helpers
     "ias_to_tas",
+    "compute_residual_risk",
     "vs_time_series",
     "integrate_altitude_from_vs",
     "encode_time_history",

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -27,6 +27,7 @@ from simulation import (
     classify_event,
     integrate_altitude_from_vs,
     ias_to_tas,
+    compute_residual_risk,
     OppositeSenseModel,
     OppositeSenseBand,
     derive_single_run_geometry,
@@ -1528,3 +1529,21 @@ def test_extend_history_with_pretrigger_adds_negative_window():
     assert np.isclose(z_ca_ext[0], 305.0)
     assert np.isclose(z_ca_ext[1], 302.5)
     assert np.isclose(z_ca_ext[2], z_ca[0])
+
+
+def test_compute_residual_risk_nominal_encounter():
+    delta_pl = 1000.0  # PL climbs 1000 ft
+    delta_cat = 3000.0  # CAT climbs 3000 ft
+
+    residual = compute_residual_risk(delta_pl, delta_cat)
+
+    assert np.isclose(residual, 0.033, atol=1e-6)
+
+
+def test_run_batch_residual_risk_preserves_sign():
+    df = run_batch(runs=1, seed=1234)
+    row = df.iloc[0]
+    expected = compute_residual_risk(row["delta_h_pl_ft"], row["delta_h_cat_ft"])
+
+    assert np.sign(expected) == np.sign(row["residual_risk"])
+    assert np.isclose(row["residual_risk"], expected, atol=1e-9)


### PR DESCRIPTION
## Summary
- add a shared residual-risk helper that preserves the sign of the PL altitude delta while guarding small magnitudes
- update the batch pipeline and Streamlit single-run view to use the signed ratio
- extend regression coverage to lock in the expected nominal residual risk magnitude and signed behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e11979e5dc8324bd08818c5b600058