### PR TITLE
Refine residual risk calculation and remove ALIM-any metric

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-ACAS/TCAS v7.1-aligned Monte Carlo — Streamlit app
+TCAS Encounter Analyser — Streamlit app
 Implements the requested amendments on top of your functioning codebase:
  A) Two‑phase RA execution (STRENGTHEN ≈ ±2500 fpm or REVERSE) with ~1 s decision latency
  B) Altitude‑dependent ALIM (≈300–700 ft bands)
@@ -110,8 +110,8 @@ def clamp_to_available_run(value: int, run_options: list[int]) -> int:
 
 # ------------------------------- Streamlit UI -------------------------------
 
-st.set_page_config(page_title="ACAS/TCAS v7.1 Monte Carlo", layout="wide")
-st.title("ACAS/TCAS v7.1‑aligned Monte Carlo")
+st.set_page_config(page_title="TCAS Encounter Analyser", layout="wide")
+st.title("TCAS Encounter Analyser")
 
 with st.sidebar:
     st.header("Simulation Controls")
@@ -407,9 +407,9 @@ with tabs[0]:
 
             delta_h_cpa = float(z_pl[-1] - z_cat[-1])
             miss_cpa = abs(delta_h_cpa)
-            delta_pl = float(z_pl[-1] - z_pl[0])
-            delta_cat = float(z_cat[-1] - z_cat[0])
-            residual_risk = compute_residual_risk(delta_pl, delta_cat)
+            delta_h_pl = float(z_pl[-1] - z_pl[0])
+            delta_h_cat = float(z_cat[-1] - z_cat[0])
+            residual_risk = compute_residual_risk(delta_h_pl, delta_h_cat)
 
             st.markdown(
                 f"**Scenario**: Head-on at FL{SINGLE_FL}, PL IAS {PL_IAS_KT:.0f} kt (TAS {pl_tas:.1f} kt), "
@@ -474,21 +474,19 @@ with tabs[1]:
         st.caption(f"ALIM applied: {alim_selection_label} (±{selected_alim_ft:.0f} ft).")
         total_runs = len(df)
         safe_total = max(total_runs, 1)
-        c1, c2, c3, c4, c5, c6 = st.columns(6)
+        c1, c2, c3, c4, c5 = st.columns(5)
         p_rev = (df['eventtype'] == "REVERSE").sum() / safe_total
         p_str = (df['eventtype'] == "STRENGTHEN").sum() / safe_total
         p_none = (df['eventtype'] == "NONE").sum() / safe_total
-        p_alim_any = (df['margin_min_ft'] < 0.0).sum() / safe_total
         sep_reference = df['sep_cpa_ft']
         p_alim_cpa = df['alim_breach_cpa'].sum() / safe_total
         c1.metric("P(Reversal)", f"{100 * p_rev:,.2f}%")
         c2.metric("P(Strengthen)", f"{100 * p_str:,.2f}%")
         c3.metric("P(None)", f"{100 * p_none:,.2f}%")
-        c4.metric("P(ALIM Any)", f"{100 * p_alim_any:,.2f}%")
         mean_cpa_sep = float(sep_reference.mean()) if total_runs else 0.0
         apfd_exec_share = float(df['CAT_is_APFD'].mean()) if total_runs else 0.0
-        c5.metric("P(ALIM @ CPA)", f"{100 * p_alim_cpa:,.2f}%")
-        c6.metric("AP/FD executions", f"{100 * apfd_exec_share:,.2f}%")
+        c4.metric("P(ALIM @ CPA)", f"{100 * p_alim_cpa:,.2f}%")
+        c5.metric("AP/FD executions", f"{100 * apfd_exec_share:,.2f}%")
         st.caption(
             "Percentages describe RA outcomes alongside CPA ALIM breaches without exclusions."
             f" Mean miss @ CPA across the batch: {mean_cpa_sep:,.1f} ft."

--- a/simulation.py
+++ b/simulation.py
@@ -195,10 +195,13 @@ def encode_time_history(
 
 
 def compute_residual_risk(delta_pl: float, delta_cat: float) -> float:
-    """Return the residual risk ratio using a signed, epsilon-guarded PL delta."""
+    """Return the residual risk ratio derived from RA-to-CPA height changes."""
 
+    delta_pl = float(delta_pl)
+    delta_cat = float(delta_cat)
     guard = delta_pl if abs(delta_pl) >= 1e-3 else math.copysign(1e-3, delta_pl or 1.0)
-    return delta_cat / guard * 0.011
+    ratio = delta_cat / guard
+    return ratio * 0.011
 
 
 def decode_time_history(value: object) -> Optional[Dict[str, np.ndarray]]:
@@ -1928,9 +1931,9 @@ def run_batch(
         alim_breach_band50 = bool(sep_trace[-1] <= band50_threshold)
         alim_breach_band100 = bool(sep_trace[-1] <= band100_threshold)
 
-        delta_pl = float(z_pl[-1] - z_pl[0])
-        delta_cat = float(z_ca[-1] - z_ca[0])
-        residual_risk = compute_residual_risk(delta_pl, delta_cat)
+        delta_h_pl = float(z_pl[-1] - z_pl[0])
+        delta_h_cat = float(z_ca[-1] - z_ca[0])
+        residual_risk = compute_residual_risk(delta_h_pl, delta_h_cat)
 
         comp_label = compliance_score_method_b_like(
             sense_required=sense_cat_exec,
@@ -1997,8 +2000,8 @@ def run_batch(
                 comp_label=comp_label,
                 CAT_is_APFD=int(cat_is_apfd),
                 residual_risk=residual_risk,
-                delta_h_pl_ft=delta_pl,
-                delta_h_cat_ft=delta_cat,
+                delta_h_pl_ft=delta_h_pl,
+                delta_h_cat_ft=delta_h_cat,
                 time_history_json=history_json,
             )
         )


### PR DESCRIPTION
## Summary
- retitle the Streamlit UI to "TCAS Encounter Analyser"
- compute residual risk from RA-to-CPA altitude deltas for single and batch reporting
- simplify batch metrics by dropping the P(ALIM Any) display

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e13c46106083248c1aa8dbf530201e