### PR TITLE
Fix batch insights subplot creation for older Matplotlib

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -625,7 +625,7 @@ with tabs[1]:
         counts = df['eventtype'].value_counts().reindex(event_order, fill_value=0)
         shares = counts / len(df)
 
-        fig, axes = plt.subplots(1, 2, figsize=(14, 5), constrained_layout=True)
+        fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
         axes[0].bar(event_order, counts[event_order], color=[color_map[e] for e in event_order])
         for idx, evt in enumerate(event_order):
@@ -652,6 +652,7 @@ with tabs[1]:
         axes[1].set_title("Initial geometry by RA outcome")
         axes[1].grid(alpha=0.2)
 
+        fig.tight_layout()
         st.pyplot(fig)
         st.caption(
             "Left: outcome mix across the batch. Right: how initial vertical separation trends with reversal/strengthen events."


### PR DESCRIPTION
## Summary
- remove the unsupported constrained_layout keyword from the batch insights subplot creation
- invoke tight_layout on the figure to keep spacing sensible across Matplotlib versions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2de841be88324b37b03767f0b0019